### PR TITLE
Block submission or edits of comments containing profanity

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,20 @@ Init db
 ```
 paster --plugin=ckanext-ytp-comments initdb --config={ckan.ini}
 ```
+
+## Profanity Filtering
+
+To enable profanity filtering, add the following configuration options to your CKAN `.ini` file:
+
+    ckan.comments.check_for_profanity = True
+
+And optionally (if you prefer a bad word list different to the one supplied):
+
+    ckan.comments.bad_words_file = /PATH/TO/BAD/WORDS.txt
+
+Profanity filtering is implemented using the `profanityfilter` python library (https://github.com/areebbeigh/profanityfilter), which is included in the `requirements.txt` file.
+
+You may need to re-install/update the requirements:
+
+    pip install -r requirements.txt
+         

--- a/ckanext/ytp/comments/bad_words.txt
+++ b/ckanext/ytp/comments/bad_words.txt
@@ -1,0 +1,1693 @@
+2 girls 1 cup
+2g1c
+4r5e
+5h1t
+5hit
+a$$
+a$$hole
+a_s_s
+a2m
+a54
+a55
+a55hole
+acrotomophilia
+aeolus
+ahole
+alabama hot pocket
+alaskan pipeline
+anal
+anal impaler
+anal leakage
+analprobe
+anilingus
+anus
+apeshit
+ar5e
+areola
+areole
+arian
+arrse
+arse
+arsehole
+aryan
+ass
+ass fuck
+ass fuck
+ass hole
+assbag
+assbandit
+assbang
+assbanged
+assbanger
+assbangs
+assbite
+assclown
+asscock
+asscracker
+asses
+assface
+assfaces
+assfuck
+assfucker
+ass-fucker
+assfukka
+assgoblin
+assh0le
+asshat
+ass-hat
+asshead
+assho1e
+asshole
+assholes
+asshopper
+ass-jabber
+assjacker
+asslick
+asslicker
+assmaster
+assmonkey
+assmucus
+assmucus
+assmunch
+assmuncher
+assnigger
+asspirate
+ass-pirate
+assshit
+assshole
+asssucker
+asswad
+asswhole
+asswipe
+asswipes
+auto erotic
+autoerotic
+axwound
+azazel
+azz
+b!tch
+b00bs
+b17ch
+b1tch
+babeland
+baby batter
+baby juice
+ball gag
+ball gravy
+ball kicking
+ball licking
+ball sack
+ball sucking
+ballbag
+balls
+ballsack
+bampot
+bang (one's) box
+bangbros
+bareback
+barely legal
+barenaked
+barf
+bastard
+bastardo
+bastards
+bastinado
+batty boy
+bawdy
+bbw
+bdsm
+beaner
+beaners
+beardedclam
+beastial
+beastiality
+beatch
+beaver
+beaver cleaver
+beaver lips
+beef curtain
+beef curtain
+beef curtains
+beeyotch
+bellend
+bender
+beotch
+bescumber
+bestial
+bestiality
+bi+ch
+biatch
+big black
+big breasts
+big knockers
+big tits
+bigtits
+bimbo
+bimbos
+bint
+birdlock
+bitch
+bitch tit
+bitch tit
+bitchass
+bitched
+bitcher
+bitchers
+bitches
+bitchin
+bitching
+bitchtits
+bitchy
+black cock
+blonde action
+blonde on blonde action
+bloodclaat
+bloody
+bloody hell
+blow job
+blow me
+blow mud
+blow your load
+blowjob
+blowjobs
+blue waffle
+blue waffle
+blumpkin
+blumpkin
+bod
+boink
+boiolas
+bollock
+bollocks
+bollok
+bollox
+bondage
+boned
+boner
+boners
+bong
+boob
+boobies
+boobs
+booby
+booger
+bookie
+boong
+booobs
+boooobs
+booooobs
+booooooobs
+bootee
+bootie
+booty
+booty call
+booze
+boozer
+boozy
+bosom
+bosomy
+breasts
+Breeder
+brotherfucker
+brown showers
+brunette action
+buceta
+bugger
+bukkake
+bull shit
+bulldyke
+bullet vibe
+bullshit
+bullshits
+bullshitted
+bullturds
+bum
+bum boy
+bumblefuck
+bumclat
+bummer
+buncombe
+bung
+bung hole
+bunghole
+bunny fucker
+bust a load
+bust a load
+busty
+butt
+butt fuck
+butt fuck
+butt plug
+buttcheeks
+buttfuck
+buttfucka
+buttfucker
+butthole
+buttmuch
+buttmunch
+butt-pirate
+buttplug
+c.0.c.k
+c.o.c.k.
+c.u.n.t
+c0ck
+c-0-c-k
+c0cksucker
+caca
+cacafuego
+cahone
+camel toe
+cameltoe
+camgirl
+camslut
+camwhore
+carpet muncher
+carpetmuncher
+cawk
+cervix
+chesticle
+chi-chi man
+chick with a dick
+child-fucker
+chinc
+chincs
+chink
+chinky
+choad
+choade
+choade
+choc ice
+chocolate rosebuds
+chode
+chodes
+chota bags
+chota bags
+cipa
+circlejerk
+cl1t
+cleveland steamer
+climax
+clit
+clit licker
+clit licker
+clitface
+clitfuck
+clitoris
+clitorus
+clits
+clitty
+clitty litter
+clitty litter
+clover clamps
+clunge
+clusterfuck
+cnut
+cocain
+cocaine
+coccydynia
+cock
+c-o-c-k
+cock pocket
+cock pocket
+cock snot
+cock snot
+cock sucker
+cockass
+cockbite
+cockblock
+cockburger
+cockeye
+cockface
+cockfucker
+cockhead
+cockholster
+cockjockey
+cockknocker
+cockknoker
+Cocklump
+cockmaster
+cockmongler
+cockmongruel
+cockmonkey
+cockmunch
+cockmuncher
+cocknose
+cocknugget
+cocks
+cockshit
+cocksmith
+cocksmoke
+cocksmoker
+cocksniffer
+cocksuck
+cocksuck
+cocksucked
+cocksucked
+cocksucker
+cock-sucker
+cocksuckers
+cocksucking
+cocksucks
+cocksucks
+cocksuka
+cocksukka
+cockwaffle
+coffin dodger
+coital
+cok
+cokmuncher
+coksucka
+commie
+condom
+coochie
+coochy
+coon
+coonnass
+coons
+cooter
+cop some wood
+cop some wood
+coprolagnia
+coprophilia
+corksucker
+cornhole
+cornhole
+corp whore
+corp whore
+corpulent
+cox
+crabs
+crack
+cracker
+crackwhore
+crap
+crappy
+creampie
+cretin
+crikey
+cripple
+crotte
+cum
+cum chugger
+cum chugger
+cum dumpster
+cum dumpster
+cum freak
+cum freak
+cum guzzler
+cum guzzler
+cumbubble
+cumdump
+cumdump
+cumdumpster
+cumguzzler
+cumjockey
+cummer
+cummin
+cumming
+cums
+cumshot
+cumshots
+cumslut
+cumstain
+cumtart
+cunilingus
+cunillingus
+cunnie
+cunnilingus
+cunny
+cunt
+c-u-n-t
+cunt hair
+cunt hair
+cuntass
+cuntbag
+cuntbag
+cuntface
+cunthole
+cunthunter
+cuntlick
+cuntlick
+cuntlicker
+cuntlicker
+cuntlicking
+cuntlicking
+cuntrag
+cunts
+cuntsicle
+cuntsicle
+cuntslut
+cunt-struck
+cunt-struck
+cus
+cut rope
+cut rope
+cyalis
+cyberfuc
+cyberfuck
+cyberfuck
+cyberfucked
+cyberfucked
+cyberfucker
+cyberfuckers
+cyberfucking
+cyberfucking
+d0ng
+d0uch3
+d0uche
+d1ck
+d1ld0
+d1ldo
+dago
+dagos
+dammit
+damn
+damned
+damnit
+darkie
+darn
+date rape
+daterape
+dawgie-style
+deep throat
+deepthroat
+deggo
+dendrophilia
+dick
+dick head
+dick hole
+dick hole
+dick shy
+dick shy
+dickbag
+dickbeaters
+dickdipper
+dickface
+dickflipper
+dickfuck
+dickfucker
+dickhead
+dickheads
+dickhole
+dickish
+dick-ish
+dickjuice
+dickmilk
+dickmonger
+dickripper
+dicks
+dicksipper
+dickslap
+dick-sneeze
+dicksucker
+dicksucking
+dicktickler
+dickwad
+dickweasel
+dickweed
+dickwhipper
+dickwod
+dickzipper
+diddle
+dike
+dildo
+dildos
+diligaf
+dillweed
+dimwit
+dingle
+dingleberries
+dingleberry
+dink
+dinks
+dipship
+dipshit
+dirsa
+dirty
+dirty pillows
+dirty sanchez
+dirty Sanchez
+div
+dlck
+dog style
+dog-fucker
+doggie style
+doggiestyle
+doggie-style
+doggin
+dogging
+doggy style
+doggystyle
+doggy-style
+dolcett
+domination
+dominatrix
+dommes
+dong
+donkey punch
+donkeypunch
+donkeyribber
+doochbag
+doofus
+dookie
+doosh
+dopey
+double dong
+double penetration
+Doublelift
+douch3
+douche
+douchebag
+douchebags
+douche-fag
+douchewaffle
+douchey
+dp action
+drunk
+dry hump
+duche
+dumass
+dumb ass
+dumbass
+dumbasses
+Dumbcunt
+dumbfuck
+dumbshit
+dummy
+dumshit
+dvda
+dyke
+dykes
+eat a dick
+eat a dick
+eat hair pie
+eat hair pie
+eat my ass
+ecchi
+ejaculate
+ejaculated
+ejaculates
+ejaculates
+ejaculating
+ejaculating
+ejaculatings
+ejaculation
+ejakulate
+erect
+erection
+erotic
+erotism
+escort
+essohbee
+eunuch
+extacy
+extasy
+f u c k
+f u c k e r
+f.u.c.k
+f_u_c_k
+f4nny
+facial
+fack
+fag
+fagbag
+fagfucker
+fagg
+fagged
+fagging
+faggit
+faggitt
+faggot
+faggotcock
+faggots
+faggs
+fagot
+fagots
+fags
+fagtard
+faig
+faigt
+fanny
+fannybandit
+fannyflaps
+fannyfucker
+fanyy
+fark
+farker
+fart
+fartknocker
+fatass
+fcuk
+fcuker
+fcuking
+fecal
+feck
+fecker
+feist
+felch
+felcher
+felching
+fellate
+fellatio
+feltch
+feltcher
+female squirting
+femdom
+fenian
+fice
+figging
+fingerbang
+fingerfuck
+fingerfuck
+fingerfucked
+fingerfucked
+fingerfucker
+fingerfucker
+fingerfuckers
+fingerfucking
+fingerfucking
+fingerfucks
+fingerfucks
+fingering
+fist fuck
+fist fuck
+fisted
+fistfuck
+fistfucked
+fistfucked
+fistfucker
+fistfucker
+fistfuckers
+fistfuckers
+fistfucking
+fistfucking
+fistfuckings
+fistfuckings
+fistfucks
+fistfucks
+fisting
+fisty
+flamer
+flange
+flaps
+fleshflute
+flog the log
+flog the log
+floozy
+foad
+foah
+fondle
+foobar
+fook
+fooker
+foot fetish
+footjob
+foreskin
+freex
+frenchify
+frigg
+frigga
+frotting
+fubar
+fuc
+fuck
+fuck
+f-u-c-k
+fuck buttons
+fuck hole
+fuck hole
+Fuck off
+fuck puppet
+fuck puppet
+fuck trophy
+fuck trophy
+fuck yo mama
+fuck yo mama
+fuck you
+fucka
+fuckass
+fuck-ass
+fuck-ass
+fuckbag
+fuck-bitch
+fuck-bitch
+fuckboy
+fuckbrain
+fuckbutt
+fuckbutter
+fucked
+fuckedup
+fucken
+fucker
+fuckers
+fuckersucker
+fuckface
+fuckhead
+fuckheads
+fuckhole
+fuckin
+fucking
+fuckings
+fuckingshitmotherfucker
+fuckme
+fuckme
+fuckmeat
+fuckmeat
+fucknugget
+fucknut
+fucknutt
+fuckoff
+fucks
+fuckstick
+fucktard
+fuck-tard
+fucktards
+fucktart
+fucktoy
+fucktoy
+fucktwat
+fuckup
+fuckwad
+fuckwhit
+fuckwit
+fuckwitt
+fudge packer
+fudgepacker
+fudge-packer
+fuk
+fuker
+fukker
+fukkers
+fukkin
+fuks
+fukwhit
+fukwit
+fuq
+futanari
+fux
+fux0r
+fvck
+fxck
+gae
+gai
+gang bang
+gangbang
+gang-bang
+gang-bang
+gangbanged
+gangbangs
+ganja
+gash
+gassy ass
+gassy ass
+gay sex
+gayass
+gaybob
+gaydo
+gayfuck
+gayfuckist
+gaylord
+gays
+gaysex
+gaytard
+gaywad
+gender bender
+genitals
+gey
+gfy
+ghay
+ghey
+giant cock
+gigolo
+gippo
+girl on
+girl on top
+girls gone wild
+git
+glans
+goatcx
+goatse
+god damn
+godamn
+godamnit
+goddam
+god-dam
+goddammit
+goddamn
+goddamned
+god-damned
+goddamnit
+godsdamn
+gokkun
+golden shower
+goldenshower
+golliwog
+gonad
+gonads
+goo girl
+gooch
+goodpoop
+gook
+gooks
+goregasm
+gringo
+grope
+group sex
+gspot
+g-spot
+gtfo
+guido
+guro
+h0m0
+h0mo
+ham flap
+ham flap
+hand job
+handjob
+hard core
+hard on
+hardcore
+hardcoresex
+he11
+hebe
+heeb
+hemp
+hentai
+heroin
+herp
+herpes
+herpy
+heshe
+he-she
+hircismus
+hitler
+hiv
+ho
+hoar
+hoare
+hobag
+hoe
+hoer
+holy shit
+hom0
+homey
+homo
+homodumbshit
+homoerotic
+homoey
+honkey
+honky
+hooch
+hookah
+hooker
+hoor
+hootch
+hooter
+hooters
+hore
+horniest
+horny
+hot carl
+hot chick
+hotsex
+how to kill
+how to murdep
+how to murder
+huge fat
+hump
+humped
+humping
+hun
+hussy
+hymen
+iap
+iberian slap
+inbred
+incest
+injun
+intercourse
+jack off
+jackass
+jackasses
+jackhole
+jackoff
+jack-off
+jaggi
+jagoff
+jail bait
+jailbait
+jap
+japs
+jelly donut
+jerk
+jerk off
+jerk0ff
+jerkass
+jerked
+jerkoff
+jerk-off
+jigaboo
+jiggaboo
+jiggerboo
+jism
+jiz
+jiz
+jizm
+jizm
+jizz
+jizzed
+jock
+juggs
+jungle bunny
+junglebunny
+junkie
+junky
+kafir
+kawk
+kike
+kikes
+kill
+kinbaku
+kinkster
+kinky
+klan
+knob
+knob end
+knobbing
+knobead
+knobed
+knobend
+knobhead
+knobjocky
+knobjokey
+kock
+kondum
+kondums
+kooch
+kooches
+kootch
+kraut
+kum
+kummer
+kumming
+kums
+kunilingus
+kunja
+kunt
+kwif
+kwif
+kyke
+l3i+ch
+l3itch
+labia
+lameass
+lardass
+leather restraint
+leather straight jacket
+lech
+lemon party
+LEN
+leper
+lesbian
+lesbians
+lesbo
+lesbos
+lez
+lezza/lesbo
+lezzie
+lmao
+lmfao
+loin
+loins
+lolita
+looney
+lovemaking
+lube
+lust
+lusting
+lusty
+m0f0
+m0fo
+m45terbate
+ma5terb8
+ma5terbate
+mafugly
+mafugly
+make me come
+male squirting
+mams
+masochist
+massa
+masterb8
+masterbat*
+masterbat3
+masterbate
+master-bate
+master-bate
+masterbating
+masterbation
+masterbations
+masturbate
+masturbating
+masturbation
+maxi
+mcfagget
+menage a trois
+menses
+menstruate
+menstruation
+meth
+m-fucking
+microphallus
+middle finger
+midget
+milf
+minge
+minger
+missionary position
+mof0
+mofo
+mo-fo
+molest
+mong
+moo moo foo foo
+moolie
+moron
+mothafuck
+mothafucka
+mothafuckas
+mothafuckaz
+mothafucked
+mothafucked
+mothafucker
+mothafuckers
+mothafuckin
+mothafucking
+mothafucking
+mothafuckings
+mothafucks
+mother fucker
+mother fucker
+motherfuck
+motherfucka
+motherfucked
+motherfucker
+motherfuckers
+motherfuckin
+motherfucking
+motherfuckings
+motherfuckka
+motherfucks
+mound of venus
+mr hands
+muff
+muff diver
+muff puff
+muff puff
+muffdiver
+muffdiving
+munging
+munter
+murder
+mutha
+muthafecker
+muthafuckker
+muther
+mutherfucker
+n1gga
+n1gger
+naked
+nambla
+napalm
+nappy
+nawashi
+nazi
+nazism
+need the dick
+need the dick
+negro
+neonazi
+nig nog
+nigaboo
+nigg3r
+nigg4h
+nigga
+niggah
+niggas
+niggaz
+nigger
+niggers
+niggle
+niglet
+nig-nog
+nimphomania
+nimrod
+ninny
+ninnyhammer
+nipple
+nipples
+nob
+nob jokey
+nobhead
+nobjocky
+nobjokey
+nonce
+nsfw images
+nude
+nudity
+numbnuts
+nut butter
+nut butter
+nut sack
+nutsack
+nutter
+nympho
+nymphomania
+octopussy
+old bag
+omg
+omorashi
+one cup two girls
+one guy one jar
+opiate
+opium
+orally
+organ
+orgasim
+orgasims
+orgasm
+orgasmic
+orgasms
+orgies
+orgy
+ovary
+ovum
+ovums
+p.u.s.s.y.
+p0rn
+paedophile
+paki
+panooch
+pansy
+pantie
+panties
+panty
+pcp
+pecker
+peckerhead
+pedo
+pedobear
+pedophile
+pedophilia
+pedophiliac
+pee
+peepee
+pegging
+penetrate
+penetration
+penial
+penile
+penis
+penisbanger
+penisfucker
+penispuffer
+perversion
+phallic
+phone sex
+phonesex
+phuck
+phuk
+phuked
+phuking
+phukked
+phukking
+phuks
+phuq
+piece of shit
+pigfucker
+pikey
+pillowbiter
+pimp
+pimpis
+pinko
+piss
+piss off
+piss pig
+pissed
+pissed off
+pisser
+pissers
+pisses
+pisses
+pissflaps
+pissin
+pissin
+pissing
+pissoff
+pissoff
+piss-off
+pisspig
+playboy
+pleasure chest
+pms
+polack
+pole smoker
+polesmoker
+pollock
+ponyplay
+poof
+poon
+poonani
+poonany
+poontang
+poop
+poop chute
+poopchute
+Poopuncher
+porch monkey
+porchmonkey
+porn
+porno
+pornography
+pornos
+potty
+prick
+pricks
+prickteaser
+prig
+prince albert piercing
+pron
+prostitute
+prude
+psycho
+pthc
+pube
+pubes
+pubic
+pubis
+punani
+punanny
+punany
+punkass
+punky
+punta
+puss
+pusse
+pussi
+pussies
+pussy
+pussy fart
+pussy fart
+pussy palace
+pussy palace
+pussylicking
+pussypounder
+pussys
+pust
+puto
+queaf
+queaf
+queef
+queer
+queerbait
+queerhole
+queero
+queers
+quicky
+quim
+racy
+raghead
+raging boner
+rape
+raped
+raper
+rapey
+raping
+rapist
+raunch
+rectal
+rectum
+rectus
+reefer
+reetard
+reich
+renob
+retard
+retarded
+reverse cowgirl
+revue
+rimjaw
+rimjob
+rimming
+ritard
+rosy palm
+rosy palm and her 5 sisters
+rtard
+r-tard
+rum
+rump
+rumprammer
+ruski
+rusty trombone
+s hit
+s&m
+s.h.i.t.
+s.o.b.
+s_h_i_t
+s0b
+sadism
+sadist
+sambo
+sand nigger
+sandbar
+sandbar
+Sandler
+sandnigger
+sanger
+santorum
+sausage queen
+sausage queen
+scag
+scantily
+scat
+schizo
+schlong
+scissoring
+screw
+screwed
+screwing
+scroat
+scrog
+scrot
+scrote
+scrotum
+scrud
+scum
+seaman
+seamen
+seduce
+seks
+semen
+sex
+sexo
+sexual
+sexy
+sh!+
+sh!t
+sh1t
+s-h-1-t
+shag
+shagger
+shaggin
+shagging
+shamedame
+shaved beaver
+shaved pussy
+shemale
+shi+
+shibari
+shirt lifter
+shit
+s-h-i-t
+shit ass
+shit fucker
+shit fucker
+shitass
+shitbag
+shitbagger
+shitblimp
+shitbrains
+shitbreath
+shitcanned
+shitcunt
+shitdick
+shite
+shiteater
+shited
+shitey
+shitface
+shitfaced
+shitfuck
+shitfull
+shithead
+shitheads
+shithole
+shithouse
+shiting
+shitings
+shits
+shitspitter
+shitstain
+shitt
+shitted
+shitter
+shitters
+shitters
+shittier
+shittiest
+shitting
+shittings
+shitty
+shiz
+shiznit
+shota
+shrimping
+sissy
+skag
+skank
+skeet
+skullfuck
+slag
+slanteye
+sleaze
+sleazy
+slope
+slut
+slut bucket
+slut bucket
+slutbag
+slutdumper
+slutkiss
+sluts
+smartass
+smartasses
+smeg
+smegma
+smut
+smutty
+snatch
+sniper
+snowballing
+snuff
+s-o-b
+sod off
+sodom
+sodomize
+sodomy
+son of a bitch
+son of a motherless goat
+son of a whore
+son-of-a-bitch
+souse
+soused
+spac
+spade
+sperm
+spic
+spick
+spik
+spiks
+splooge
+splooge moose
+spooge
+spook
+spread legs
+spunk
+stfu
+stiffy
+stoned
+strap on
+strapon
+strappado
+strip
+strip club
+stroke
+stupid
+style doggy
+suck
+suckass
+sucked
+sucking
+sucks
+suicide girls
+sultry women
+sumofabiatch
+swastika
+swinger
+t1t
+t1tt1e5
+t1tties
+taff
+taig
+tainted love
+taking the piss
+tampon
+tard
+tart
+taste my
+tawdry
+tea bagging
+teabagging
+teat
+teets
+teez
+teste
+testee
+testes
+testical
+testicle
+testis
+threesome
+throating
+thrust
+thug
+thundercunt
+tied up
+tight white
+tinkle
+tit
+tit wank
+tit wank
+titfuck
+titi
+tities
+tits
+titt
+tittie5
+tittiefucker
+titties
+titty
+tittyfuck
+tittyfucker
+tittywank
+titwank
+toke
+tongue in a
+toots
+topless
+tosser
+towelhead
+tramp
+tranny
+transsexual
+trashy
+tribadism
+trumped
+tub girl
+tubgirl
+turd
+tush
+tushy
+tw4t
+twat
+twathead
+twatlips
+twats
+twatty
+twatwaffle
+twink
+twinkie
+two fingers
+two fingers with tongue
+two girls one cup
+twunt
+twunter
+unclefucker
+undies
+undressing
+unwed
+upskirt
+urethra play
+urinal
+urine
+urophilia
+uterus
+uzi
+v14gra
+v1gra
+vag
+vagina
+vajayjay
+va-j-j
+valium
+venus mound
+veqtable
+viagra
+vibrator
+violet wand
+virgin
+vixen
+vjayjay
+vodka
+vomit
+vorarephilia
+voyeur
+vulgar
+vulva
+w00se
+wad
+wang
+wank
+wanker
+wankjob
+wanky
+wazoo
+wedgie
+weed
+weenie
+weewee
+weiner
+weirdo
+wench
+wet dream
+wetback
+wh0re
+wh0reface
+white power
+whiz
+whoar
+whoralicious
+whore
+whorealicious
+whorebag
+whored
+whoreface
+whorehopper
+whorehouse
+whores
+whoring
+wigger
+willies
+willy
+window licker
+wiseass
+wiseasses
+wog
+womb
+wop
+wrapping men
+wrinkled starfish
+wtf
+xrated
+x-rated
+xx
+xxx
+yaoi
+yeasty
+yellow showers
+yid
+yiffy
+yobbo
+zibbi
+zoophilia
+zubb

--- a/ckanext/ytp/comments/controller.py
+++ b/ckanext/ytp/comments/controller.py
@@ -39,12 +39,16 @@ class CommentController(BaseController):
                 success = True
             except ValidationError, ve:
                 log.debug(ve)
+                if ve.error_dict and ve.error_dict.get('message'):
+                    msg = ve.error_dict['message']
+                else:
+                    msg = str(ve)
+                h.flash_error(msg)
             except Exception, e:
                 log.debug(e)
                 abort(403)
 
-            if success:
-                h.redirect_to(str('/dataset/%s#comment_%s' % (c.pkg.name, res['id'])))
+            h.redirect_to(str('/dataset/%s#edit_%s' % (c.pkg.name, res['id'] if success else comment_id)))
 
         return render("package/read.html")
 

--- a/ckanext/ytp/comments/helpers.py
+++ b/ckanext/ytp/comments/helpers.py
@@ -1,0 +1,20 @@
+from ckan.common import config
+from profanityfilter import ProfanityFilter
+
+
+def profanity_check(cleaned_comment):
+    more_words = load_bad_words()
+
+    pf = ProfanityFilter(extra_censor_list=more_words)
+    return pf.is_profane(cleaned_comment)
+
+
+def load_bad_words():
+    filepath = config.get('ckan.comments.bad_words_file', None)
+    if not filepath:
+        import os
+        filepath = os.path.dirname(os.path.realpath(__file__)) + '/bad_words.txt'
+    f = open(filepath, 'r')
+    x = f.read().splitlines()
+    f.close()
+    return x

--- a/ckanext/ytp/comments/logic/action/update.py
+++ b/ckanext/ytp/comments/logic/action/update.py
@@ -1,9 +1,13 @@
 import datetime
+import ckan.plugins.toolkit as toolkit
 import ckanext.ytp.comments.model as comment_model
 import ckanext.ytp.comments.util as util
 from ckan import logic
 from ckan.lib.base import abort
 import logging
+
+from ckan.common import config
+from ckanext.ytp.comments import helpers
 
 log = logging.getLogger(__name__)
 
@@ -24,6 +28,11 @@ def comment_update(context, data_dict):
 
     # Cleanup the comment
     cleaned_comment = util.clean_input(data_dict.get('comment'))
+
+    # Run profanity check
+    if toolkit.asbool(config.get('ckan.comments.check_for_profanity', False)) \
+            and (helpers.profanity_check(cleaned_comment) or helpers.profanity_check(data_dict.get('subject', ''))):
+        raise logic.ValidationError("Comment blocked due to profanity.")
 
     comment.subject = data_dict.get('subject')
     comment.comment = cleaned_comment

--- a/ckanext/ytp/comments/public/javascript/comment_validation.js
+++ b/ckanext/ytp/comments/public/javascript/comment_validation.js
@@ -4,6 +4,26 @@ function hideFormErrors()
     jQuery('.form_errors li').addClass('hidden');
 }
 
+function showFormErrors()
+{
+    jQuery('#comment_form_errors').removeClass('hidden');
+}
+
+function showFormError(id, error_name)
+{
+    jQuery('#' + id + ' .error-' + error_name).removeClass('hidden');
+}
+
+function showEditFormErrors(id)
+{
+    jQuery('#' + id + ' .edit_form_errors').removeClass('hidden');
+}
+
+function showReplyFormErrors(id)
+{
+    jQuery('#' + id + ' .reply_form_errors').removeClass('hidden');
+}
+
 jQuery(document).ready(function() {
 
     jQuery('.module-content input[type="submit"]').on('click', function(e) {
@@ -24,5 +44,53 @@ jQuery(document).ready(function() {
             }
         }
     });
+
+    if (window.location.hash) {
+        var hash = window.location.hash;
+        var hash_no_hash = hash.substring(1); //Puts hash in variable, and removes the # character
+        if (hash_no_hash == 'comment_form') {
+            //  Regex the flash-messages for 'subject' 'comment' and 'profanity'
+            if (jQuery('#content .flash-messages').children().length > 0) {
+                var error_message = jQuery('#content .flash-messages').text()
+                //  Check for profanity error message
+                if (error_message.search("profanity") !== -1) {
+                    jQuery('#comment_form_errors .error-profanity').removeClass('hidden');
+                    showFormErrors();
+                }
+            }
+        }
+        else if (hash_no_hash.indexOf('edit_') !== -1) {
+            var form_wrapper_id = 'comment_form_' + hash_no_hash;
+            jQuery(hash).removeClass('hidden');
+            document.getElementById(form_wrapper_id).scrollIntoView();
+            //  Regex the flash-messages for 'subject' 'comment' and 'profanity'
+            if (jQuery('#content .flash-messages').children().length > 0) {
+                var error_message = jQuery('#content .flash-messages').text()
+                //  Check for profanity error message
+                if (error_message.search("profanity") !== -1) {
+                    showFormError(form_wrapper_id, 'profanity');
+                    showEditFormErrors(form_wrapper_id);
+                }
+            }
+        }
+        else if (hash_no_hash.indexOf('reply_') !== -1) {
+            var form_wrapper_id = 'comment_form_' + hash_no_hash;
+            var parent_comment_wrapper_id = 'comment_' + hash_no_hash.replace('reply_', '');
+            jQuery(hash).removeClass('hidden');
+            document.getElementById(parent_comment_wrapper_id).scrollIntoView();
+            //  Regex the flash-messages for 'subject' 'comment' and 'profanity'
+            if (jQuery('#content .flash-messages').children().length > 0) {
+                var error_message = jQuery('#content .flash-messages').text()
+                //  Check for profanity error message
+                if (error_message.search("profanity") !== -1) {
+                    showFormError(form_wrapper_id, 'profanity');
+                    showReplyFormErrors(form_wrapper_id);
+                }
+            }
+        }
+        else if (hash.indexOf('#comment_') !== -1) {
+            jQuery(hash).addClass('highlight');
+        }
+    }
 
 });

--- a/ckanext/ytp/comments/templates/package/comment_list.html
+++ b/ckanext/ytp/comments/templates/package/comment_list.html
@@ -58,7 +58,9 @@
 
                 {% if userobj and comment.user_id == userobj.id %}
                     <li><a onclick="ShowCommentForm('edit_{{ comment.id }}')">{{ _('Edit') }}</a></li>
-                    {{ comment_form(comment, prefix='edit_', action='edit') }}
+                    <div id="comment_form_edit_{{ comment.id }}">
+                        {{ comment_form(comment, prefix='edit_', action='edit') }}
+                    </div>
                 {% endif %}
                 {% if userobj %}
                     <li><a onclick="ShowCommentForm('reply_{{ comment.id }}')">{{ _('Reply') }}</a> </li>

--- a/ckanext/ytp/comments/templates/package/comment_list.html
+++ b/ckanext/ytp/comments/templates/package/comment_list.html
@@ -7,6 +7,7 @@
     <form id="{{ prefix + values.id }}" class="form {% if hidden %}hidden{% endif %}" action="{{ pkg_id }}/comments/{% if values.id %}{{ values.id }}/{% endif %}{{ action }}" method="POST">
         <div class="{{ action }}_form_errors form-errors alert alert-error hidden">
             <div class="hidden error-comment">{{ _('Please enter a Comment.') }}</div>
+            <div class="hidden error-profanity">{{ _('Comment blocked due to profanity.') }}</div>
         </div>
         <div class="form-controls">
             <label for="subject">{{ _('Subject') }}</label>
@@ -28,8 +29,8 @@
 
 {% macro comment_thread(thread) %}
 
-    <div class="comment-wrapper">
     {% for comment in thread.comments %}
+    <div id="comment_{{ comment.id }}" class="comment-wrapper">
         {{ comment.id }}
         <div class="comment">
             {% if comment.state != 'deleted' %}
@@ -61,7 +62,9 @@
                 {% endif %}
                 {% if userobj %}
                     <li><a onclick="ShowCommentForm('reply_{{ comment.id }}')">{{ _('Reply') }}</a> </li>
-                    {{ comment_form(comment, empty=True, prefix='reply_', action='reply') }}
+                    <div id="comment_form_reply_{{ comment.id }}">
+                        {{ comment_form(comment, empty=True, prefix='reply_', action='reply') }}
+                    </div>
                 {% endif %}
 
             </ul>
@@ -71,8 +74,8 @@
             {% if comment.comments | length != 0 %}
                 {{ comment_thread(comment) }}
             {% endif %}
-    {% endfor %}
     </div>
+    {% endfor %}
 
 {% endmacro %}
 <h3 id="comments">{{ _('Comments') }}</h3>
@@ -82,9 +85,10 @@
 
 {% if userobj %}
 
-<form class="form" action="{{ pkg_id }}/comments/add" method="POST">
+<form id="comment_form" class="form" action="{{ pkg_id }}/comments/add" method="POST">
     <div id="comment_form_errors" class="alert alert-error form-errors hidden">
         <div class="hidden error-comment">{{ _('Please enter a Comment.') }}</div>
+        <div class="hidden error-profanity">{{ _('Comment blocked due to profanity.') }}</div>
     </div>
     <div class="form-controls">
         <label for="subject">{{ _('Subject') }}</label>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 lxml==4.4.1
+profanityfilter


### PR DESCRIPTION
### Purpose

This pull request adds functionality to block submission or edits of comments containing profanity.

### Approach

The Python `profanityfilter` library is used to validate comment submissions and edits against a list of bad words.
If a user submits a comment, or edits a comment to contain profanity in the subject or comment text, its is blocked and an error message appears.

![image](https://user-images.githubusercontent.com/26393708/73832518-2ce40e80-486d-11ea-8ae5-2dc0238fcd5f.png)

- Added auth changes submitted in PR 1 (#1)
- `lxml 4.4.1` added to requirements to satisfy installation of the extension
