### PR TITLE
Email dataset owner when new comment added

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,5 @@ The following config options can be added to the CKAN `.ini` file to enable emai
     ckan.comments.email_notification_to = author
 
 Valid values are: `author` or `maintainer` defaults to `author` if incorrectly set, or not set and `ckan.comments.email_notifications_enabled = True`
+
+**Note:** emails are sent via a queued job using the standard CKAN Job Worker: https://docs.ckan.org/en/2.8/maintaining/background-tasks.html

--- a/README.md
+++ b/README.md
@@ -31,3 +31,15 @@ Init db
 ```
 paster --plugin=ckanext-ytp-comments initdb --config={ckan.ini}
 ```
+
+## Email Notifications
+
+The following config options can be added to the CKAN `.ini` file to enable email notifications whenever a new comment is added:
+
+    ckan.comments.email_notifications_enabled = True
+
+(defaults to `False`)
+
+    ckan.comments.email_notification_to = author
+
+Valid values are: `author` or `maintainer` defaults to `author` if incorrectly set, or not set and `ckan.comments.email_notifications_enabled = True`

--- a/ckanext/ytp/comments/controller.py
+++ b/ckanext/ytp/comments/controller.py
@@ -1,8 +1,9 @@
+import email_notifications
 import logging
 
 from ckan.lib.base import h, BaseController, render, abort, request
 from ckan import model
-from ckan.common import c
+from ckan.common import c, config
 from ckan.logic import check_access, get_action, clean_dict, tuplize_dict, ValidationError, parse_params
 from ckan.lib.navl.dictization_functions import unflatten
 
@@ -94,6 +95,12 @@ class CommentController(BaseController):
                 abort(403)
 
             if success:
+                if config.get('ckan.comments.email_notifications_enabled', False):
+                    email_notifications.notify_admin(
+                        'notification-new-comment',
+                        dataset_id,
+                        res['id']
+                    )
                 h.redirect_to(str('/dataset/%s#comment_%s' % (c.pkg.name, res['id'])))
 
         return render("package/read.html")

--- a/ckanext/ytp/comments/email_notifications.py
+++ b/ckanext/ytp/comments/email_notifications.py
@@ -1,0 +1,105 @@
+import ckan.lib.mailer as mailer
+import ckan.logic as logic
+import ckan.model as model
+import ckan.plugins.toolkit as toolkit
+import logging
+
+from ckan.common import config
+from ckan.lib.base import render_jinja2
+
+
+log1 = logging.getLogger(__name__)
+NotFound = logic.NotFound
+
+
+def get_dataset_owner_email(dataset_id):
+    """
+    Returns the email address of the dataset author or maintainer
+    :param dataset_id: string
+    :return: string of dataset author or maintainer email address
+    """
+    context = {'model': model}
+    dataset = logic.get_action('package_show')(context, {'id': dataset_id})
+
+    email_notification_to = config.get('ckan.comments.email_notification_to')
+
+    if not email_notification_to or email_notification_to not in ['author', 'maintainer']:
+        email_notification_to = 'author'
+
+    return dataset.get(email_notification_to + '_email', None) if dataset else None
+
+
+def send_email(to, subject, msg):
+    """
+    Use CKAN mailer logic to send an email to an individual email address
+
+    :param to: string
+    :param subject: string
+    :param msg: string
+    :return:
+    """
+    # Attempt to send mail.
+    mail_dict = {
+        'recipient_email': to,
+        'recipient_name': to,
+        'subject': subject,
+        'body': msg,
+        'headers': {'reply-to': config.get('smtp.mail_from')}
+    }
+
+    try:
+        mailer.mail_recipient(**mail_dict)
+    except mailer.MailerException:
+        log1.error(u'Cannot send email notification to %s.', to, exc_info=1)
+
+
+def send_notification_emails(users, template, extra_vars):
+    """
+    Sets the email body and sends an email notification to each user in the list provided
+
+    :param users: list of user email addresses to receive the notification
+    :param template: string indicating which email template to use
+    :param extra_vars: dict
+    :return:
+    """
+    if users:
+        subject = render_jinja2('emails/subjects/{0}.txt'.format(template), extra_vars)
+        body = render_jinja2('emails/bodies/{0}.txt'.format(template), extra_vars)
+
+        for user in users:
+            toolkit.enqueue_job(send_email, [user, subject, body], title=u'Comment Email')
+    return users
+
+
+def notify_admin(template, content_item_id, comment_id):
+    """
+    :param template: string indicating which email template to use
+    :param content_item_id: UUID of the content item
+    :param comment_id: ID of the comment submitted (used in URL of email body)
+    :return:
+    """
+    owner_email = get_dataset_owner_email(content_item_id)
+    admin_user = [owner_email] if owner_email else []
+
+    if admin_user:
+        send_notification_emails(
+            admin_user,
+            template,
+            {
+                'url': get_content_item_link(content_item_id, comment_id)
+            }
+        )
+
+
+def get_content_item_link(content_item_id, comment_id=None):
+    """
+    Get a fully qualified URL to the content item being commented on.
+
+    :param content_item_id: string Package name, or Data Request ID
+    :param comment_id: string `comment`.`id`
+    :return:
+    """
+    url = toolkit.url_for('dataset_read', id=content_item_id, qualified=True)
+    if comment_id:
+        url += '#comment_' + str(comment_id)
+    return url

--- a/ckanext/ytp/comments/logic/auth/delete.py
+++ b/ckanext/ytp/comments/logic/auth/delete.py
@@ -1,7 +1,7 @@
 import logging
 from pylons.i18n import _
 
-import ckan.new_authz as new_authz
+import ckan.authz as authz
 from ckan import logic
 import ckanext.ytp.comments.model as comment_model
 
@@ -15,7 +15,7 @@ def comment_delete(context, data_dict):
 
     userobj = model.User.get(user)
     # If sysadmin.
-    if new_authz.is_sysadmin(user):
+    if authz.is_sysadmin(user):
         return {'success': True}
 
     cid = logic.get_or_bust(data_dict, 'id')

--- a/ckanext/ytp/comments/templates/emails/bodies/notification-new-comment.txt
+++ b/ckanext/ytp/comments/templates/emails/bodies/notification-new-comment.txt
@@ -1,0 +1,5 @@
+A comment has been made that may be relevant to you.
+
+{{ url }}
+
+Do not reply to this email.

--- a/ckanext/ytp/comments/templates/emails/subjects/notification-new-comment.txt
+++ b/ckanext/ytp/comments/templates/emails/subjects/notification-new-comment.txt
@@ -1,0 +1,1 @@
+Comment Notification


### PR DESCRIPTION
### Purpose

This pull request adds functionality to email dataset owners when a new comment has been added to their datasets.

### Approach

Adds two new configuration options to the CKAN `.ini` file:

1. to enable email notifications: `ckan.comments.email_notifications_enabled` (Defaults to `False`)
2. to set who should receive the email notification: `ckan.comments.email_notification_to` (can be set to `author`, or `maintainer`. Defaults to `author`)

Emails the author or maintainer of the dataset based on the CKAN `.ini` file setting `ckan.comments.email_notification_to`,  to notify them that a new 
a new comment has been added their dataset.

Adds email notification subject and body templates to the extension in the `/templates/emails/` directory.

Uses the CKAN job worker to send emails to avoid latency between comment submission and front-end display of updated comments.