### PR TITLE
Comment email notifications for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,31 @@ Init db
 ```
 paster --plugin=ckanext-ytp-comments initdb --config={ckan.ini}
 ```
+
+## Follow / Mute comments
+
+Comment notifications (via email) are managed by opt-in, i.e. without opting in to receive comment notifications at the content item or thread level, only authors or organisation admins will receive email notifications. 
+
+This feature allows users to following or mute comments at the content item level or for a specific comment thread on the content item.
+
+When a user follows comments on a content item or content item thread they will receive email notifications when new comments or replies are posted.
+
+### Setup
+
+1. Initialise the comment notification receipients database table, e.g.
+
+        cd /usr/lib/ckan/default/src/ckanext-ytp-comments # Your PATH may vary
+        
+        paster init_notifications_db -c /etc/ckan/default/development.ini # Use YOUR path and relevant CKAN .ini file
+
+    This will create a new table in the CKAN database named `comment_notification_recipient` that holds the status of individual user's follow or mute preferences.
+    
+    *Note:* if your deployment process does not run `python setup.py develop` after deploying code changes for extensions, you may need to run this in order for paster to recognise the `init_notifications_db` command:
+
+        python setup.py develop
+
+2. Add the following config setting to your CKAN `.ini` file:
+
+        ckan.comments.follow_mute_enabled = True
+
+3. Restart CKAN

--- a/ckanext/ytp/comments/command.py
+++ b/ckanext/ytp/comments/command.py
@@ -1,6 +1,9 @@
+import ckan.model as model
 import logging
 
 from ckan.lib.cli import CkanCommand
+
+log = logging.getLogger(__name__)
 
 
 class InitDBCommand(CkanCommand):
@@ -18,7 +21,6 @@ class InitDBCommand(CkanCommand):
         super(InitDBCommand, self).__init__(name)
 
     def command(self):
-        log = logging.getLogger(__name__)
         log.info("starting command")
         self._load_config()
 
@@ -30,3 +32,22 @@ class InitDBCommand(CkanCommand):
         log.info("Initializing tables")
         cmodel.init_tables()
         log.info("DB tables are setup")
+
+
+class InitNotificationsDB(CkanCommand):
+    """Initialise the comment extension's notifications database tables
+    """
+    summary = __doc__.split('\n')[0]
+    usage = __doc__
+    max_args = 0
+    min_args = 0
+
+    def command(self):
+        self._load_config()
+
+        model.Session.remove()
+        model.Session.configure(bind=model.meta.engine)
+
+        import notification_models
+        notification_models.init_tables()
+        log.debug("Comment notification preference DB table is setup")

--- a/ckanext/ytp/comments/email_notifications.py
+++ b/ckanext/ytp/comments/email_notifications.py
@@ -1,0 +1,260 @@
+import ckan.authz as authz
+import ckan.lib.mailer as mailer
+import ckan.logic as logic
+import ckan.model as model
+import ckan.plugins.toolkit as toolkit
+import logging
+import notification_helpers
+
+from ckan.common import config
+from ckan.lib.base import render_jinja2
+
+
+log1 = logging.getLogger(__name__)
+NotFound = logic.NotFound
+
+
+def get_member_list(context, data_dict=None):
+    '''
+    :param id: the id or name of the group
+    :type id: string
+    :param object_type: restrict the members returned to those of a given type,
+      e.g. ``'user'`` or ``'package'`` (optional, default: ``None``)
+    :type object_type: string
+    :param capacity: restrict the members returned to those with a given
+      capacity, e.g. ``'member'``, ``'editor'``, ``'admin'``, ``'public'``,
+      ``'private'`` (optional, default: ``None``)
+    :type capacity: string
+
+    :rtype: list of (id, type, capacity) tuples
+
+    :raises: :class:`ckan.logic.NotFound`: if the group doesn't exist
+
+    '''
+    model = context['model']
+
+    group = model.Group.get(logic.get_or_bust(data_dict, 'id'))
+    if not group:
+        raise NotFound
+
+    obj_type = data_dict.get('object_type', None)
+    capacity = data_dict.get('capacity', None)
+
+    q = model.Session.query(model.Member).\
+        filter(model.Member.group_id == group.id).\
+        filter(model.Member.state == "active")
+
+    if obj_type:
+        q = q.filter(model.Member.table_name == obj_type)
+    if capacity:
+        q = q.filter(model.Member.capacity == capacity)
+
+    trans = authz.roles_trans()
+
+    def translated_capacity(capacity):
+        try:
+            return trans[capacity]
+        except KeyError:
+            return capacity
+
+    return [(m.table_id, m.table_name, translated_capacity(m.capacity))
+            for m in q.all()]
+
+
+def get_users_for_org_by_capacity(owner_org, capacity, excluded_emails=[]):
+    """
+    Returns a list of user email addresses in the supplied organisation ID, for a given capacity
+
+    :param owner_org: string
+    :param capacity: string
+    :param excluded_emails: list of email addresses to exclude
+    :return: list of user email addresses
+    """
+    users = []
+
+    member_list = get_member_list(
+        {'model': model},
+        {
+            'id': owner_org,
+            'object_type': 'user',
+            'capacity': capacity
+        })
+
+    for member in member_list:
+        user = model.User.get(member[0])
+        if user and user.email and user.email not in excluded_emails:
+            users.append(user.email)
+
+    return users
+
+
+def get_dataset_author_email(dataset_id):
+    """
+    Returns the email address of the dataset author
+    :param dataset_id: string
+    :return: string of dataset author email address
+    """
+    context = {'model': model}
+    dataset = logic.get_action('package_show')(context, {'id': dataset_id})
+
+    return dataset.get('author_email', None) if dataset else None
+
+
+def send_email(to, subject, msg):
+    """
+    Use CKAN mailer logic to send an email to an individual email address
+
+    :param to: string
+    :param subject: string
+    :param msg: string
+    :return:
+    """
+    # Attempt to send mail.
+    mail_dict = {
+        'recipient_email': to,
+        'recipient_name': to,
+        'subject': subject,
+        'body': msg,
+        'headers': {'reply-to': config.get('smtp.mail_from')}
+    }
+
+    try:
+        mailer.mail_recipient(**mail_dict)
+    except mailer.MailerException:
+        log1.error(u'Cannot send email notification to %s.', to, exc_info=1)
+
+
+def send_notification_emails(users, template, extra_vars):
+    """
+    Sets the email body and sends an email notification to each user in the list provided
+
+    :param users: list of user email addresses to receive the notification
+    :param template: string indicating which email template to use
+    :param extra_vars: dict
+    :return:
+    """
+    if users:
+        subject = render_jinja2('emails/subjects/{0}.txt'.format(template), extra_vars)
+        body = render_jinja2('emails/bodies/{0}.txt'.format(template), extra_vars)
+
+        for user in users:
+            toolkit.enqueue_job(send_email, [user, subject, body], title=u'Comment Email')
+
+
+def get_admins(owner_org, user, content_type, content_item_id):
+    if content_type == 'dataset':
+        author_email = get_dataset_author_email(content_item_id)
+        users = [author_email] if author_email else []
+    else:
+        # Get all the org admin users (excluding the user who made the comment)
+        users = get_users_for_org_by_capacity(owner_org, 'admin', [user.email])
+    return users
+
+
+def notify_admins(owner_org, user, template, content_type, content_item_id, comment_id):
+    """
+
+    :param owner_org: organization.id of the content item owner
+    :param user: c.user_obj of the user who submitted the comment
+    :param template: string indicating which email template to use
+    :param content_type: string dataset or datarequest
+    :param content_item_id: UUID of the content item
+    :param comment_id: ID of the comment submitted (used in URL of email body)
+    :return:
+    """
+    admin_users = get_admins(owner_org, user, content_type, content_item_id)
+
+    if admin_users:
+        send_notification_emails(
+            admin_users,
+            template,
+            {
+                'url': get_content_item_link(content_type, content_item_id, comment_id)
+            }
+        )
+
+
+def notify_admins_and_comment_notification_recipients(owner_org, user, template, content_type, content_item_id, thread_id, parent_id, comment_id):
+
+    admin_users = get_admins(owner_org, user, content_type, content_item_id)
+
+    if notification_helpers.comment_notification_recipients_enabled():
+        # Get email addresses for all users following the content item (excluding user who made the comment)
+        content_item_followers = notification_helpers.get_content_item_followers(user.email, thread_id)
+
+        if parent_id:
+            # Get email addresses for all users following the top level comment (excluding user who made the comment)
+            top_level_comment_followers = notification_helpers.get_top_level_comment_followers(user.email, thread_id, parent_id)
+        else:
+            top_level_comment_followers = []
+
+    if notification_helpers.comment_notification_recipients_enabled():
+        # Combine all lists
+        users = list(set(admin_users + content_item_followers + top_level_comment_followers))
+
+        # Remove any users who have specifically muted the thread
+        if parent_id:
+            top_level_comment_mutees = notification_helpers.get_top_level_comment_mutees(thread_id, parent_id)
+            for mutee in top_level_comment_mutees:
+                if mutee in users:
+                    try:
+                        users.remove(mutee)
+                    except ValueError:
+                        continue
+    else:
+        users = list(set(admin_users))
+
+    if users:
+        send_notification_emails(
+            users,
+            template,
+            {
+                'url': get_content_item_link(content_type, content_item_id, comment_id)
+            }
+        )
+
+
+def get_content_item_link(content_type, content_item_id, comment_id=None):
+    """
+    Get a fully qualified URL to the content item being commented on.
+
+    :param content_type: string Currently only supports 'dataset' or 'datarequest'
+    :param content_item_id: string Package name, or Data Request ID
+    :param comment_id: string `comment`.`id`
+    :return:
+    """
+    url = ''
+    if content_type == 'datarequest':
+        url = toolkit.url_for('comment_datarequest', id=content_item_id, qualified=True)
+    else:
+        url = toolkit.url_for('dataset_read', id=content_item_id, qualified=True)
+    if comment_id:
+        url += '#comment_' + str(comment_id)
+    return url
+
+
+def get_content_type_and_org_id(context, thread_url, content_item_id):
+    """
+    Derives the content type and ID of the owning organisation from the comment thread URL and the content item ID
+
+    :param context:
+    :param thread_url:
+    :param content_item_id:
+    :return:
+    """
+    org_id = None
+    data_dict = {'id': content_item_id}
+    try:
+        if thread_url.find('datarequest') != -1:
+            content_type = 'datarequest'
+            action = 'show_datarequest'
+        else:
+            content_type = 'dataset'
+            action = 'package_show'
+        content_item = logic.get_action(action)(context, data_dict)
+        if content_item:
+            org_id = content_item['organization_id'] if content_type == 'datarequest' else content_item['owner_org']
+    except NotFound:
+        log1.error('Content item (%s) with ID %s not found' % (content_type, content_item_id))
+
+    return content_type, org_id

--- a/ckanext/ytp/comments/fanstatic/ytp_comments.css
+++ b/ckanext/ytp/comments/fanstatic/ytp_comments.css
@@ -1,0 +1,10 @@
+.comment {
+    border-bottom: 1px solid #ddd;
+    margin-bottom: 10px;
+    padding-bottom: 10px;
+}
+
+.comment-container .comment-wrapper .comment-wrapper {
+    margin-left: 4em;
+    margin-bottom: 0;
+}

--- a/ckanext/ytp/comments/helpers.py
+++ b/ckanext/ytp/comments/helpers.py
@@ -1,0 +1,19 @@
+import ckan.plugins.toolkit as toolkit
+import logging
+
+from ckan.common import c
+
+log = logging.getLogger(__name__)
+
+
+def get_org_id(content_type):
+    return c.datarequest['organization_id'] if content_type == 'datarequest' else c.pkg.owner_org
+
+
+def get_content_item_id(content_type):
+    return c.datarequest['id'] if content_type == 'datarequest' else c.pkg.name
+
+
+def get_user_id():
+    user = toolkit.c.userobj
+    return user.id

--- a/ckanext/ytp/comments/logic/auth/delete.py
+++ b/ckanext/ytp/comments/logic/auth/delete.py
@@ -1,7 +1,7 @@
 import logging
 from pylons.i18n import _
 
-import ckan.new_authz as new_authz
+import ckan.authz as authz
 from ckan import logic
 import ckanext.ytp.comments.model as comment_model
 
@@ -15,7 +15,7 @@ def comment_delete(context, data_dict):
 
     userobj = model.User.get(user)
     # If sysadmin.
-    if new_authz.is_sysadmin(user):
+    if authz.is_sysadmin(user):
         return {'success': True}
 
     cid = logic.get_or_bust(data_dict, 'id')

--- a/ckanext/ytp/comments/model.py
+++ b/ckanext/ytp/comments/model.py
@@ -247,6 +247,8 @@ class Comment(Base):
             d['comments'] = [c.as_dict() for c in self.children if c.state == 'active']
         else:
             d['comments'] = [c.as_dict() for c in self.children]
+        if self.parent_id:
+            d['parent_id'] = self.parent_id
         return d
 
     @classmethod

--- a/ckanext/ytp/comments/notification_controller.py
+++ b/ckanext/ytp/comments/notification_controller.py
@@ -1,0 +1,69 @@
+import ckan.authz as authz
+import notification_helpers
+import re
+
+from ckan.lib.base import BaseController, abort
+
+
+class NotificationController(BaseController):
+
+    def valid_request_and_user(self, thread_or_comment_id):
+        """
+        Check user logged in and perform simple validation of id provided in request
+        :param thread_or_comment_id:
+        :return:
+        """
+        return False if not authz.auth_is_loggedin_user() \
+            or not id \
+            or self.contains_invalid_chars(thread_or_comment_id) else True
+
+    def contains_invalid_chars(self, value):
+        return re.search(r"[^0-9a-f-]", value)
+
+    def follow(self, thread_or_comment_id=None):
+        """
+        Add the user to the list of comment notification email recipients
+        :param thread_or_comment_id: A UUID - can be either a thread ID or a specific top level comment ID
+        :return:
+        """
+        return self.follow_or_mute(thread_or_comment_id, 'follow')
+
+    def mute(self, thread_or_comment_id=None):
+        """
+        Remove the user from the list of comment notification email recipients
+        :param thread_or_comment_id: A UUID - can be either a thread ID or a specific top level comment ID
+        :return:
+        """
+        return self.follow_or_mute(thread_or_comment_id, 'mute')
+
+    def follow_or_mute(self, thread_or_comment_id, action):
+        """
+        *** Developers, please note: *** within YTP comments, a "thread" represents a set of comments for a given
+        dataset or data request, whereas the meaning in the Jira story differs, i.e. it refers to a top level comment
+        and it's subsequent replies. Where possible we use the code/YTP concept of "thread"
+
+        :param thread_or_comment_id: UUID - can be either a thread ID (in the YTP sense) or a comment ID
+        :param action: string - "follow" or "mute"
+        :return:
+        """
+        if not self.valid_request_and_user(thread_or_comment_id):
+            abort(404)
+
+        thread, comment = notification_helpers.get_thread_comment_or_both(thread_or_comment_id)
+
+        if not thread or (comment and not thread):
+            abort(404)
+
+        notification_level = 'content_item' if not comment else 'top_level_comment'
+
+        user_id = notification_helpers.get_user_id()
+
+        # Check for an existing record - helps us prevent re-adding the user to recipients table
+        existing_record = notification_helpers.get_existing_record(user_id, thread.id, comment.id if comment else None)
+
+        if action == 'follow':
+            notification_helpers.process_follow_request(user_id, thread, comment, existing_record, notification_level)
+
+        # User is muting comments at content item level or specific comment thread within that content item
+        elif action == 'mute':
+            notification_helpers.process_mute_request(user_id, thread, comment, existing_record, notification_level)

--- a/ckanext/ytp/comments/notification_helpers.py
+++ b/ckanext/ytp/comments/notification_helpers.py
@@ -1,0 +1,243 @@
+import ckan.model as model
+import ckan.plugins.toolkit as toolkit
+import logging
+import sqlalchemy
+
+from ckan.common import config
+from model import Comment, CommentThread
+from notification_models import CommentNotificationRecipient
+
+_and_ = sqlalchemy.and_
+log = logging.getLogger(__name__)
+
+
+def comment_notification_recipients_enabled():
+    return config.get('ckan.comments.follow_mute_enabled', False)
+
+
+def get_thread_comment_or_both(thread_or_comment_id):
+    """
+    Determine if provided ID is for a thread or comment
+    :param thread_or_comment_id: UUID - can be either a thread ID (in the YTP sense) or a comment ID
+    :return: CommentThread object, and Comment object (if applicable)
+    """
+    thread = CommentThread.get(thread_or_comment_id)
+
+    if thread:
+        comment = None
+    else:
+        # Fallback: check for comment by id provided...
+        comment = Comment.get(thread_or_comment_id)
+        if comment:
+            thread = CommentThread.get(comment.thread_id)
+
+    return thread, comment
+
+
+def get_existing_record(user_id, thread_id, comment_id=None):
+    # Condition doesn't seem to get set properly within _and_ filter
+    if not comment_id:
+        comment_id = u''
+
+    record = (
+        model.Session.query(
+            CommentNotificationRecipient
+        )
+        .filter(
+            _and_(
+                CommentNotificationRecipient.user_id == user_id,
+                CommentNotificationRecipient.thread_id == thread_id,
+                CommentNotificationRecipient.comment_id == comment_id
+            )
+        )
+    ).first()
+
+    return record
+
+
+def get_comment_notification_records_for_user(user_id, thread_id):
+    try:
+        records = (
+            model.Session.query(
+                CommentNotificationRecipient
+            )
+            .filter(
+                _and_(
+                    CommentNotificationRecipient.user_id == user_id,
+                    CommentNotificationRecipient.thread_id == thread_id
+                )
+            )
+        )
+        return records
+    except Exception, e:
+        log.error('Unable to retrieve comment notification statuses')
+        log.error(str(e))
+
+
+def get_user_comment_follow_mute_status(user_id, content_item_thread_id):
+    following_content_item = False
+    comments_following = []
+    comments_muted = []
+
+    for record in get_comment_notification_records_for_user(user_id, content_item_thread_id):
+        if record.comment_id == u'':
+            following_content_item = True
+        elif record.action == 'follow':
+            comments_following.append(record.comment_id)
+        elif record.action == 'mute':
+            comments_muted.append(record.comment_id)
+
+    return following_content_item, comments_following, comments_muted
+
+
+def remove_comment_notification_record(record):
+    try:
+        model.Session.delete(record)
+        model.Session.commit()
+    except Exception, e:
+        log.error('Error removing `comment_notification_recipient` record:')
+        log.error(str(e))
+
+
+def remove_existing_follows_for_user(user_id, thread_id):
+    follows = get_comment_notification_records_for_user(user_id, thread_id)
+    for record in follows:
+        remove_comment_notification_record(record)
+
+
+def add_comment_notification_record(user_id, thread_id, comment_id, notification_level, action):
+    data_dict = {
+        'user_id': user_id,
+        'thread_id': thread_id,
+        'comment_id': comment_id,
+        'notification_level': notification_level,
+        'action': action
+    }
+    try:
+        model.Session.add(CommentNotificationRecipient(**data_dict))
+        model.Session.commit()
+    except Exception, e:
+        log.error('Error adding `comment_notification_recipient` record:')
+        log.error(str(e))
+
+
+def add_user_to_comment_notifications(user_id, thread_id, comment_id=u''):
+    # Is the user attempting to follow at the dataset/data request or the comment level?
+    notification_level = 'top_level_comment' if comment_id else 'content_item'
+    add_comment_notification_record(user_id, thread_id, comment_id, notification_level, 'follow')
+
+
+def add_commenter_to_comment_notifications(user_id, thread_id, comment_id=u''):
+    existing_record = get_existing_record(user_id, thread_id, comment_id)
+    if existing_record and existing_record.action == 'mute':
+        remove_comment_notification_record(existing_record)
+        add_user_to_comment_notifications(user_id, thread_id, comment_id)
+    elif not existing_record or (existing_record and existing_record.action != 'follow'):
+        add_user_to_comment_notifications(user_id, thread_id, comment_id)
+
+
+def mute_comment_thread_for_user(user_id, thread_id, comment_id):
+    add_comment_notification_record(user_id, thread_id, comment_id, 'top_level_comment', 'mute')
+
+
+def process_follow_request(user_id, thread, comment, existing_record, notification_level):
+
+    following_content_item, \
+        comments_following, \
+        comments_muted = get_user_comment_follow_mute_status(
+            user_id,
+            thread.id
+        )
+
+    if notification_level == 'content_item':
+        # Check if user already following comments at content item level
+        if following_content_item:
+            return 'User already following comments at content item level'
+        else:
+            add_user_to_comment_notifications(user_id, thread.id)
+    else:
+        if comment.id in comments_following:
+            return 'User already following thread'
+        else:
+            if comment.id in comments_muted and existing_record and existing_record.action == 'mute':
+                # Remove existing mute record
+                remove_comment_notification_record(existing_record)
+            # If user is following comments at content item level and no mute record in place,
+            # there is no need to add follow record for specific comment thread..
+            if not following_content_item:
+                add_user_to_comment_notifications(user_id, thread.id, comment.id)
+
+
+def process_mute_request(user_id, thread, comment, existing_record, notification_level):
+
+    following_content_item, \
+        comments_following, \
+        comments_muted = get_user_comment_follow_mute_status(
+            user_id,
+            thread.id
+        )
+
+    if notification_level == 'content_item':
+        # When user mutes comments at content item level we remove ALL existing records for that user
+        # in the `comment_notification_recipient` table for the matching YTP thread.id
+        remove_existing_follows_for_user(user_id, thread.id)
+        return 'Comments muted at content item level for user'
+    elif comment.id in comments_muted:
+        return 'Thread already muted for user'
+    else:
+        if comment.id in comments_following and existing_record and existing_record.action == 'follow':
+            # Remove existing follow record
+            remove_comment_notification_record(existing_record)
+        # Only need to add mute record if user is following comments at content item level
+        if comment.id not in comments_muted and following_content_item:
+            mute_comment_thread_for_user(user_id, thread.id, comment.id)
+
+        return 'Thread muted for user'
+
+
+def get_comment_notification_recipients(action, user_email, thread_id, comment_id=None):
+    try:
+        if not comment_id:
+            comment_id = u''
+
+        session = model.Session
+        emails = (
+            session.query(
+                model.User.email
+            )
+            .join(
+                CommentNotificationRecipient,
+                CommentNotificationRecipient.user_id == model.User.id
+            )
+            .filter(CommentNotificationRecipient.thread_id == thread_id)
+            .filter(CommentNotificationRecipient.comment_id == comment_id)
+            .filter(CommentNotificationRecipient.action == action)
+            .filter(model.User.email != user_email)
+            .group_by(model.User.email)
+        )
+        return [email[0] for email in emails.all()]
+    except Exception, e:
+        log.error('Exception raised in `get_comment_notification_recipients`')
+        log.error(str(e))
+    return []
+
+
+def get_content_item_followers(user_email, thread_id):
+    return get_comment_notification_recipients('follow', user_email, thread_id)
+
+
+def get_top_level_comment_followers(user_email, thread_id, comment_id):
+    return get_comment_notification_recipients('follow', user_email, thread_id, comment_id)
+
+
+def get_top_level_comment_mutees(thread_id, comment_id):
+    return get_comment_notification_recipients('mute', None, thread_id, comment_id)
+
+
+def get_comment_notification_recipients_enabled():
+    return config.get('ckan.comments.follow_mute_enabled', False)
+
+
+def get_user_id():
+    user = toolkit.c.userobj
+    return user.id

--- a/ckanext/ytp/comments/notification_models.py
+++ b/ckanext/ytp/comments/notification_models.py
@@ -1,0 +1,37 @@
+import ckan.model as model
+import datetime
+
+from sqlalchemy import Table, Column, MetaData
+from sqlalchemy import types
+from sqlalchemy.orm import mapper
+from ckan.model.types import make_uuid
+
+log = __import__('logging').getLogger(__name__)
+
+metadata = MetaData()
+
+
+class CommentNotificationRecipient(object):
+
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+        self.id = make_uuid()
+        self.timestamp = datetime.datetime.utcnow()
+
+
+comment_notification_recipient_table = Table('comment_notification_recipient', metadata,
+                                             Column('id', types.UnicodeText, primary_key=True,
+                                                    default=make_uuid),
+                                             Column('timestamp', types.DateTime, default=datetime.datetime.utcnow()),
+                                             Column('user_id', types.UnicodeText),
+                                             Column('thread_id', types.UnicodeText),
+                                             Column('comment_id', types.UnicodeText, default=u''),
+                                             Column('notification_level', types.UnicodeText),
+                                             Column('action', types.UnicodeText)
+                                             )
+mapper(CommentNotificationRecipient, comment_notification_recipient_table)
+
+
+def init_tables():
+    metadata.create_all(model.meta.engine)

--- a/ckanext/ytp/comments/plugin.py
+++ b/ckanext/ytp/comments/plugin.py
@@ -2,6 +2,7 @@ import ckan.plugins as plugins
 from ckan.plugins import implements, toolkit
 
 import logging
+import notification_helpers
 
 log = logging.getLogger(__name__)
 
@@ -23,11 +24,14 @@ class YtpCommentsPlugin(plugins.SingletonPlugin):
         toolkit.add_template_directory(config, "templates")
         toolkit.add_public_directory(config, 'public')
         toolkit.add_resource('public/javascript/', 'comments_js')
+        toolkit.add_resource('fanstatic', 'ytp_comments')
 
     def get_helpers(self):
         return {
             'get_comment_thread': self._get_comment_thread,
-            'get_comment_count_for_dataset': self._get_comment_count_for_dataset
+            'get_comment_count_for_dataset': self._get_comment_count_for_dataset,
+            'user_comment_follow_mute_status': notification_helpers.get_user_comment_follow_mute_status,
+            'comment_notification_recipients_enabled': notification_helpers.get_comment_notification_recipients_enabled
         }
 
     def get_actions(self):
@@ -70,6 +74,10 @@ class YtpCommentsPlugin(plugins.SingletonPlugin):
         map.connect('/dataset/{dataset_id}/comments/{comment_id}/edit', controller=controller, action='edit')
         map.connect('/dataset/{dataset_id}/comments/{parent_id}/reply', controller=controller, action='reply')
         map.connect('/dataset/{dataset_id}/comments/{comment_id}/delete', controller=controller, action='delete')
+        # Routes for following and muting comment notifications
+        notification_controller = 'ckanext.ytp.comments.notification_controller:NotificationController'
+        map.connect('/comments/{thread_or_comment_id}/follow', controller=notification_controller, action='follow')
+        map.connect('/comments/{thread_or_comment_id}/mute', controller=notification_controller, action='mute')
         return map
 
     def _get_comment_thread(self, dataset_name):

--- a/ckanext/ytp/comments/public/javascript/confirm_mute_content_item.js
+++ b/ckanext/ytp/comments/public/javascript/confirm_mute_content_item.js
@@ -1,0 +1,141 @@
+this.ckan.module('confirm-mute-content-item', function (jQuery) {
+  return {
+    /* An object of module options */
+    options: {
+      /* Content can be overriden by setting data-module-content to a
+       * *translated* string inside the template, e.g.
+       *
+       *     <a href="..."
+       *        data-module="confirm-action"
+       *        data-module-content="{{ _('Are you sure?') }}">
+       *    {{ _('Delete') }}
+       *    </a>
+       */
+      content: '',
+
+      /* This is part of the old i18n system and is kept for backwards-
+       * compatibility for templates which set the content via the
+       * `i18n.content` attribute instead of via the `content` attribute
+       * as described above.
+       */
+      i18n: {
+        content: '',
+      },
+
+      template: [
+        '<div class="modal fade">',
+        '<div class="modal-dialog">',
+        '<div class="modal-content">',
+        '<div class="modal-header">',
+        '<button type="button" class="close" data-dismiss="modal">×</button>',
+        '<h3 class="modal-title"></h3>',
+        '</div>',
+        '<div class="modal-body"></div>',
+        '<div class="modal-footer">',
+        '<button class="btn btn-default btn-cancel"></button>',
+        '<button class="btn btn-primary"></button>',
+        '</div>',
+        '</div>',
+        '</div>',
+        '</div>'
+      ].join('\n')
+    },
+
+    /* Sets up the event listeners for the object. Called internally by
+     * module.createInstance().
+     *
+     * Returns nothing.
+     */
+    initialize: function () {
+      jQuery.proxyAll(this, /_on/);
+      this.el.on('click', this._onClick);
+    },
+
+    /* Presents the user with a confirm dialogue to ensure that they wish to
+     * continue with the current action.
+     *
+     * Examples
+     *
+     *   jQuery('.delete').click(function () {
+     *     module.confirm();
+     *   });
+     *
+     * Returns nothing.
+     */
+    confirm: function () {
+      this.sandbox.body.append(this.createModal());
+      this.modal.modal('show');
+
+      // Center the modal in the middle of the screen.
+      this.modal.css({
+        'margin-top': this.modal.height() * -0.5,
+        'top': '50%'
+      });
+    },
+
+    /* Performs the action for the current item.
+     *
+     * Returns nothing.
+     */
+    performAction: function (thread_id) {
+      var element = this.modal;
+      var el = this.el;
+      jQuery.get(this.el.attr('href'), function() {
+        jQuery(el).addClass('hidden');
+        jQuery(el).parent().find('.comments-follow').removeClass('hidden');
+        element.modal('hide');
+        jQuery('.comments-mute-thread').each(function(){
+          if (!jQuery(this).hasClass('hidden')) {
+            jQuery(this).addClass('hidden');
+            jQuery(this).parent().find('.comments-follow-thread').removeClass('hidden');
+          }
+        });
+      })
+      .fail(function() {
+        element.find('.modal-title').text('Error');
+        element.find('.modal-body').text('An unexpected error has occurred. Please close this pop-up and try again.');
+      });
+
+    },
+
+    /* Creates the modal dialog, attaches event listeners and localised
+     * strings.
+     *
+     * Returns the newly created element.
+     */
+    createModal: function () {
+      if (!this.modal) {
+        var element = this.modal = jQuery(this.options.template);
+        element.on('click', '.btn-primary', this._onConfirmSuccess);
+        element.on('click', '.btn-cancel', this._onConfirmCancel);
+        element.modal({show: false});
+
+        var title = jQuery(this.el).attr('title') || 'Confirm action';
+        element.find('.modal-title').text(title);
+        var content = this.options.content ||
+                      this.options.i18n.content || /* Backwards-compatibility */
+                      this._('Are you sure you want to perform this action?');
+        element.find('.modal-body').text(content);
+        element.find('.btn-primary').text(this._('Confirm'));
+        element.find('.btn-cancel').text(this._('Cancel'));
+      }
+      return this.modal;
+    },
+
+    /* Event handler that displays the confirm dialog */
+    _onClick: function (event) {
+      event.preventDefault();
+      this.confirm();
+    },
+
+    /* Event handler for the success event */
+    _onConfirmSuccess: function (event) {
+      this.performAction();
+    },
+
+    /* Event handler for the cancel event */
+    _onConfirmCancel: function (event) {
+      this.modal.modal('hide');
+    }
+  };
+});

--- a/ckanext/ytp/comments/public/javascript/follow_or_mute_notifications.js
+++ b/ckanext/ytp/comments/public/javascript/follow_or_mute_notifications.js
@@ -1,0 +1,125 @@
+this.ckan.module('follow-or-mute', function (jQuery) {
+  return {
+    /* An object of module options */
+    options: {
+      /* Content can be overriden by setting data-module-content to a
+       * *translated* string inside the template, e.g.
+       *
+       *     <a href="..."
+       *        data-module="confirm-action"
+       *        data-module-content="{{ _('Are you sure?') }}">
+       *    {{ _('Delete') }}
+       *    </a>
+       */
+      content: '',
+
+      /* This is part of the old i18n system and is kept for backwards-
+       * compatibility for templates which set the content via the
+       * `i18n.content` attribute instead of via the `content` attribute
+       * as described above.
+       */
+      i18n: {
+        content: '',
+      },
+
+      template: [
+        '<div class="modal fade">',
+        '<div class="modal-dialog">',
+        '<div class="modal-content">',
+        '<div class="modal-header">',
+        '<button type="button" class="close" data-dismiss="modal">×</button>',
+        '<h3 class="modal-title"></h3>',
+        '</div>',
+        '<div class="modal-body"></div>',
+        '<div class="modal-footer">',
+        '<button class="btn btn-primary"></button>',
+        '</div>',
+        '</div>',
+        '</div>',
+        '</div>'
+      ].join('\n')
+    },
+
+    /* Sets up the event listeners for the object. Called internally by
+     * module.createInstance().
+     *
+     * Returns nothing.
+     */
+    initialize: function () {
+      jQuery.proxyAll(this, /_on/);
+      this.el.on('click', this._onClick);
+    },
+
+    /* Presents the user with a modal dialogue to notify them that a
+     * thread has been followed or muted
+     *
+     * Returns nothing.
+     */
+    displayModal: function () {
+      this.sandbox.body.append(this.createModal());
+      this.modal.modal('show');
+
+      // Center the modal in the middle of the screen.
+      this.modal.css({
+        'margin-top': this.modal.height() * -0.5,
+        'top': '50%'
+      });
+    },
+
+    /* Creates the modal dialog, attaches event listeners and localised
+     * strings.
+     *
+     * Returns the newly created element.
+     */
+    createModal: function () {
+      if (!this.modal) {
+        var element = this.modal = jQuery(this.options.template);
+        element.on('click', '.btn-primary', this._onClose);
+        element.modal({show: false});
+
+        element.find('.modal-title').text(this.options.title);
+
+        var content = this.options.content ||
+                      this.options.i18n.content || /* Backwards-compatibility */
+                      this._('Thread followed.');
+        element.find('.modal-body').text(content);
+        element.find('.btn-primary').text(this._('Close'));
+      }
+      return this.modal;
+    },
+
+    /* Event handler that displays the confirm dialog */
+    _onClick: function (event) {
+      event.preventDefault();
+      var action = 'follow';
+      var inverse = 'mute';
+      if (this.options.action === 'mute') {
+          action = 'mute';
+          inverse = 'follow';
+      }
+      var content_type = this.options.content_type;
+      var thread_id = this.options.thread_id;
+      var comment_id = this.options.comment_id;
+      var element = this;
+      this.options.title = jQuery(element.el).attr('title');
+      jQuery.get('/comments/' + (thread_id ? thread_id : comment_id) + '/' + action, function() {
+        jQuery(element.el).addClass('hidden');
+        jQuery(element.el).parent().find('.comments-' + inverse + (thread_id ? '' : '-thread')).removeClass('hidden');
+        if (!comment_id) {
+          jQuery('.comments-follow-thread').addClass('hidden');
+          jQuery('.comments-mute-thread').removeClass('hidden');
+        }
+      })
+      .fail(function() {
+        element.options.content = 'An error occurred while attempting to ' + action + ' this ' + (thread_id ? content_type : 'thread') + '.';
+      });
+      this.displayModal();
+      return false;
+    },
+
+    /* Event handler for the close event */
+    _onClose: function (event) {
+      this.modal.modal('hide');
+    }
+  };
+});

--- a/ckanext/ytp/comments/templates/emails/bodies/notification-new-comment.txt
+++ b/ckanext/ytp/comments/templates/emails/bodies/notification-new-comment.txt
@@ -1,4 +1,4 @@
-A comment has been made on the Queensland Government open data portal that may be relevant to you.
+A comment has been made that may be relevant to you.
 
 {{ url }}
 

--- a/ckanext/ytp/comments/templates/emails/bodies/notification-new-comment.txt
+++ b/ckanext/ytp/comments/templates/emails/bodies/notification-new-comment.txt
@@ -1,0 +1,5 @@
+A comment has been made on the Queensland Government open data portal that may be relevant to you.
+
+{{ url }}
+
+Do not reply to this email.

--- a/ckanext/ytp/comments/templates/emails/subjects/notification-new-comment.txt
+++ b/ckanext/ytp/comments/templates/emails/subjects/notification-new-comment.txt
@@ -1,0 +1,1 @@
+Queensland Government Open Data - Comments

--- a/ckanext/ytp/comments/templates/emails/subjects/notification-new-comment.txt
+++ b/ckanext/ytp/comments/templates/emails/subjects/notification-new-comment.txt
@@ -1,1 +1,1 @@
-Queensland Government Open Data - Comments
+Comment Notification

--- a/ckanext/ytp/comments/templates/package/comment_list.html
+++ b/ckanext/ytp/comments/templates/package/comment_list.html
@@ -1,6 +1,18 @@
 
 
+{% resource "ytp_comments/ytp_comments.css" %}
 {% resource "comments_js/comments.js" %}
+
+{% set content_type = content_type or 'dataset' %}
+{% set thread = h.get_comment_thread(pkg_name) %}
+
+{% set notification_actions_enabled = userobj and h.comment_notification_recipients_enabled() %}
+
+{% if notification_actions_enabled %}
+    {% resource "comments_js/confirm_mute_content_item.js" %}
+    {% resource "comments_js/follow_or_mute_notifications.js" %}
+    {% set following_content_item, comments_following, comments_muted = h.user_comment_follow_mute_status(userobj.id, thread.id) %}
+{% endif %}
 
 {% macro comment_form(values={}, empty=False, hidden=True, prefix="", action="add") %}
     <form id="{{ prefix + values.id }}" class="form {% if hidden %}hidden{% endif %}" action="{{ pkg_id }}/comments/{% if values.id %}{{ values.id }}/{% endif %}{{ action }}" method="POST">
@@ -18,15 +30,10 @@
     </form>
 {% endmacro %}
 
-
-
-{% set thread = h.get_comment_thread(pkg_name) %}
-
 {% macro comment_thread(thread) %}
 
     <div class="comment-wrapper">
     {% for comment in thread.comments %}
-        {{ comment.id }}
         <div class="comment">
             {% if comment.state != 'deleted' %}
                 <h3>{{ comment.subject }}</h3>
@@ -39,6 +46,9 @@
                     <br/><span>{{ h.render_datetime(comment.modified_date, "%d.%m.%Y %H:%M") }} {{ _('Modified') }} </span>
                 {% endif %}
             </div>
+            {% if notification_actions_enabled %}
+                {% snippet "snippets/comment_thread_notification_actions.html", following_content=following_content_item, following=(comment.id in comments_following), muted=(comment.id in comments_muted), comment_id=comment.id %}
+            {% endif %}
             <div class="content">
             {% if comment.state != 'deleted' %}
                 {{ comment.content|safe }}
@@ -72,6 +82,11 @@
 
 {% endmacro %}
 <h3 id="comments">{{ _('Comments') }}</h3>
+
+{% if notification_actions_enabled %}
+    {% snippet "snippets/content_item_notification_actions.html", following=following_content_item, content_type=content_type, thread_id=thread.id %}
+{% endif %}
+
 <div class="comment-container">
     {{ comment_thread(thread) }}
 </div>

--- a/ckanext/ytp/comments/templates/snippets/comment_thread_notification_actions.html
+++ b/ckanext/ytp/comments/templates/snippets/comment_thread_notification_actions.html
@@ -1,0 +1,30 @@
+{% set base_url = '/comments/' + comment_id %}
+
+{% macro comment_thread_action_button(base_url, comment_id, action, following, muted) %}
+    {% set btn_style = 'btn-' + ('success' if action == 'follow' else 'warning') %}
+    {% set title = 'Thread ' + ('followed' if action == 'follow' else 'muted') %}
+    {% set data_module_content = 'You are now following comments on this thread.' if action == 'follow' else 'You have muted comment notifications on this thread.' %}
+
+    {% if action == 'follow' and (following or (following_content and not muted)) %}
+        {% set hidden_class = True %}
+    {% elif action == 'mute' and (muted or (not following_content and not following)) %}
+        {% set hidden_class = True %}
+    {% else %}
+        {% set hidden_class = False %}
+    {% endif %}
+
+    <button href="{{ base_url }}/{{action}}"
+            class="btn btn-xs {{ btn_style }} comments-{{ action }}-thread {{ 'hidden' if hidden_class }}"
+            title="{{ title }}"
+            data-module="follow-or-mute"
+            data-module-action="{{ action }}"
+            data-module-content="{{ data_module_content }}"
+            data-module-comment_id="{{ comment_id }}">
+        {{ 'Follow' if action == 'follow' else 'Mute' }} thread
+    </button>
+{% endmacro %}
+
+<div class="comment-action">
+    {{ comment_thread_action_button(base_url, comment_id, 'follow', following, muted) }}
+    {{ comment_thread_action_button(base_url, comment_id, 'mute', following, muted) }}
+</div>

--- a/ckanext/ytp/comments/templates/snippets/content_item_notification_actions.html
+++ b/ckanext/ytp/comments/templates/snippets/content_item_notification_actions.html
@@ -1,0 +1,20 @@
+{% set base_url = '/comments/' + thread_id %}
+<div class="notification-actions">
+    <button href="{{ base_url }}/follow"
+            class="btn btn-success comments-follow {{ 'hidden' if following }}"
+            title="{{ content_type[0]|upper }}{{ content_type[1:] }} followed"
+            data-module="follow-or-mute"
+            data-module-action="follow"
+            data-module-content="You are now following comments on this {{ content_type }}."
+            data-module-content_type="{{ content_type }}"
+            data-module-thread_id="{{ thread_id }}">
+        Follow comments
+    </button>
+    <button href="{{ base_url }}/mute"
+            class="btn btn-warning comments-mute {{ 'hidden' if not following }}"
+            title="Mute comments"
+            data-module="confirm-mute-content-item"
+            data-module-content="By muting comments on this {{ content_type }} you will no longer receive any email notifications on this {{ content_type }} when new comments are posted. Are you sure?">
+        Mute comments
+    </button>
+</div>

--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,6 @@ setup(
 
         [paste.paster_command]
         initdb = ckanext.ytp.comments.command:InitDBCommand
+        init_notifications_db = ckanext.ytp.comments.command:InitNotificationsDB
     ''',
 )


### PR DESCRIPTION
### Purpose

This pull request adds functionality for users to follow or mute comments at the dataset level or for a specific comment thread of a dataset.

Comment notifications (via email) are managed by opt-in. This gives users full control over which comments they will receive notifications for (or none).

When a user adds a new comment, or replies to an existing comment, they will automatically follow that thread.

### Approach

- Added a new setting in CKAN `.ini` file `ckan.comments.follow_mute_enabled` to enable follow/mute UI (default: False).

- A new database model (`comment_notification_recipient`) was added to the extension. A paster command is also added to initialise the database table in the CKAN postgres database.

- Comment follow and mute routes were added to the extension, along with a controller class to handle requests via those routes.

- A helper function file was created to isolate required functionality and enable reuse of those functions.

- The comment list template was adjusted to add follow/mute related markup via template snippets, along with the necessary CSS, Javascript code and email notification templates.

![image](https://user-images.githubusercontent.com/26393708/73986171-d2000380-49a1-11ea-84e7-c4108364a061.png)

